### PR TITLE
Only autoprefix in production

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.rb]
+indent_style = space
+indent_size = 2

--- a/lib/jekyll-autoprefixer.rb
+++ b/lib/jekyll-autoprefixer.rb
@@ -21,5 +21,7 @@ Jekyll::Hooks.register :site, :post_render do |site|
 end
 
 Jekyll::Hooks.register :site, :post_write do |site|
-  site.autoprefixer.process
+  if Jekyll.env == "production"
+    site.autoprefixer.process
+  end
 end

--- a/lib/jekyll/autoprefixer/version.rb
+++ b/lib/jekyll/autoprefixer/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Autoprefixer
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end


### PR DESCRIPTION
This was handy for me, because in development I use browser-sync to hot-reload css changes, and autoprefixing made that behave badly. I realize some people might not want this behavior, so I certainly understand if this PR isn't accepted.