### PR TITLE
Update to autoprefixer-rails 7

### DIFF
--- a/jekyll-autoprefixer.gemspec
+++ b/jekyll-autoprefixer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 1.9.3'
-  spec.add_runtime_dependency 'autoprefixer-rails', '~> 6.3.6'
+  spec.add_runtime_dependency 'autoprefixer-rails', '~> 7.1.0'
   spec.add_development_dependency 'jekyll', '~> 3.1.2'
   spec.add_development_dependency "bundler", "~> 1.6"
 end


### PR DESCRIPTION
Upgrading to autoprefixer-rails 7.1 works around the following sprockets deprecation warning:

```
      Generating...
DEPRECATION WARNING: You are using the a deprecated processor interface #<Proc:0x007fb2552d9cb8@/opt/boxen/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/autoprefixer-rails-6.3.7/lib/autoprefixer-rails/sprockets.rb:37>.
Please update your processor interface:
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
 (called from install at /opt/boxen/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/autoprefixer-rails-6.3.7/lib/autoprefixer-rails/sprockets.rb:37)
                    done in 1.515 seconds.
```