### PR TITLE
Note autoprefixer as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 This plugin provides simple autoprefixer support for Jekyll.
 
+## Prerequisites
+
+You need to have the [autoprefixer](https://www.npmjs.com/package/autoprefixer) package installed for this plugin to work.
+```
+npm i -D autoprefixer
+```
+
 ## Installation
 
 This plugin is available as a [RubyGem][ruby-gem].


### PR DESCRIPTION
After reading that "no additional steps are required" I assumed there was some sort of ruby implementation of autoprefixer. It seemed like this plugin just didn't work.