### PR TITLE
Update autoprefixer-rails to fix execjs issue

### DIFF
--- a/jekyll-autoprefixer.gemspec
+++ b/jekyll-autoprefixer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 1.9.3'
-  spec.add_runtime_dependency 'autoprefixer-rails', '~> 9.3'
+  spec.add_runtime_dependency 'autoprefixer-rails', '~> 10.2.5.1'
   spec.add_development_dependency 'jekyll', '~> 3.8'
   spec.add_development_dependency "bundler", "~> 1.6"
 end


### PR DESCRIPTION
Related to #11 . Update autoprefixer-rails to v10.2.5.1. See https://github.com/vwochnik/jekyll-autoprefixer/issues/11#issuecomment-850694593